### PR TITLE
Add Xtool Studio Electron application

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "xtool-studio",
+  "version": "0.1.0",
+  "description": "Cross-platform desktop wrapper for the xtool CLI",
+  "main": "dist/main/main.js",
+  "author": "",
+  "license": "MIT",
+  "scripts": {
+    "clean": "rimraf dist",
+    "dev": "cross-env NODE_ENV=development concurrently \"npm:dev:renderer\" \"npm:dev:main\" \"npm:dev:preload\" \"npm:dev:electron\"",
+    "dev:renderer": "vite",
+    "dev:main": "tsc -p tsconfig.main.json --watch",
+    "build": "npm run clean && npm run build:main && npm run build:preload && npm run build:renderer",
+    "build:main": "tsc -p tsconfig.main.json",
+    "build:preload": "tsc -p tsconfig.preload.json",
+    "build:renderer": "vite build",
+    "make:linux": "npm run build && electron-builder --linux AppImage deb",
+    "make:win": "npm run build && electron-builder --win nsis",
+    "dev:preload": "tsc -p tsconfig.preload.json --watch",
+    "dev:electron": "wait-on dist/main/main.js && wait-on tcp:5173 && electron ."
+  },
+  "dependencies": {
+    "@types/node-pty": "^0.11.7",
+    "electron-store": "^9.0.0",
+    "keytar": "^7.9.0",
+    "node-pty": "^1.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "ansi_up": "^5.2.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "concurrently": "^8.0.0",
+    "cross-env": "^7.0.3",
+    "electron": "^27.0.0",
+    "electron-builder": "^24.6.0",
+    "rimraf": "^5.0.0",
+    "typescript": "^5.3.0",
+    "vite": "^5.0.0",
+    "wait-on": "^7.0.1"
+  },
+  "build": {
+    "appId": "com.example.xtoolstudio",
+    "productName": "Xtool Studio",
+    "files": [
+      "dist/main/**/*",
+      "dist/preload/**/*",
+      "dist/renderer/**/*",
+      "package.json"
+    ],
+    "directories": {
+      "output": "release"
+    },
+    "linux": {
+      "target": [
+        "AppImage",
+        "deb"
+      ],
+      "category": "Development"
+    },
+    "win": {
+      "target": "nsis"
+    },
+    "extraMetadata": {
+      "main": "dist/main/main.js"
+    }
+  }
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,0 +1,268 @@
+import { app, BrowserWindow, dialog, ipcMain, shell } from 'electron';
+import path from 'path';
+import Store from 'electron-store';
+import keytar from 'keytar';
+import fs from 'fs';
+import { spawn as spawnChild } from 'child_process';
+import { PtyManager, PtyRequest } from './pty';
+
+const isDev = !app.isPackaged;
+const store = new Store({
+  name: 'xtool-studio',
+  defaults: {
+    recentProjects: [] as string[],
+    globalSettings: {
+      xtoolPath: process.platform === 'win32' ? 'xtool.exe' : 'xtool'
+    },
+    projectSettings: {} as Record<string, any>
+  }
+});
+
+let mainWindow: BrowserWindow | null = null;
+const ptyManager = new PtyManager();
+
+function createWindow() {
+  mainWindow = new BrowserWindow({
+    width: 1280,
+    height: 800,
+    title: 'Xtool Studio',
+    webPreferences: {
+      preload: path.join(__dirname, '../preload/preload.js'),
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: false
+    }
+  });
+
+  ptyManager.bindWindow(mainWindow);
+
+  if (isDev) {
+    mainWindow.loadURL('http://localhost:5173');
+    mainWindow.webContents.openDevTools({ mode: 'detach' });
+  } else {
+    mainWindow.loadFile(path.join(__dirname, '../renderer/index.html'));
+  }
+
+  mainWindow.on('closed', () => {
+    mainWindow = null;
+  });
+
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    shell.openExternal(url);
+    return { action: 'deny' };
+  });
+}
+
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow();
+    }
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});
+
+ipcMain.handle('dialog:selectDirectory', async () => {
+  if (!mainWindow) return null;
+  const result = await dialog.showOpenDialog(mainWindow, {
+    properties: ['openDirectory']
+  });
+  if (result.canceled || result.filePaths.length === 0) {
+    return null;
+  }
+  return result.filePaths[0];
+});
+
+ipcMain.handle('projects:getRecent', () => {
+  return store.get('recentProjects', []) as string[];
+});
+
+
+ipcMain.handle('project:analyze', async (_event, projectPath: string) => {
+  if (!projectPath) {
+    return null;
+  }
+  const hasPackageSwift = fs.existsSync(path.join(projectPath, 'Package.swift'));
+  const hasXtoolConfig = fs.existsSync(path.join(projectPath, 'xtool.json')) || fs.existsSync(path.join(projectPath, 'xtool.yaml')) || fs.existsSync(path.join(projectPath, 'xtool.yml'));
+  return { hasPackageSwift, hasXtoolConfig };
+});
+
+ipcMain.handle('projects:addRecent', (_event, projectPath: string) => {
+  const recents = new Set(store.get('recentProjects', []) as string[]);
+  if (projectPath) {
+    recents.delete(projectPath);
+    recents.add(projectPath);
+  }
+  const ordered = Array.from(recents).slice(-10).reverse();
+  store.set('recentProjects', ordered);
+  return ordered;
+});
+
+ipcMain.handle('settings:get', (_event, payload: { scope: 'global' | 'project'; key?: string; projectPath?: string; }) => {
+  if (payload.scope === 'global') {
+    const all = store.get('globalSettings', {});
+    return payload.key ? (all as any)[payload.key] : all;
+  }
+  const projectSettings = store.get('projectSettings', {}) as Record<string, any>;
+  const project = payload.projectPath ? projectSettings[payload.projectPath] ?? {} : {};
+  return payload.key ? project?.[payload.key] : project;
+});
+
+ipcMain.handle('settings:set', (_event, payload: { scope: 'global' | 'project'; key: string; value: any; projectPath?: string; }) => {
+  if (payload.scope === 'global') {
+    const current = store.get('globalSettings', {});
+    (current as any)[payload.key] = payload.value;
+    store.set('globalSettings', current);
+    return current;
+  }
+  const projectSettings = store.get('projectSettings', {}) as Record<string, any>;
+  const projectPath = payload.projectPath ?? 'default';
+  const project = projectSettings[projectPath] ?? {};
+  project[payload.key] = payload.value;
+  projectSettings[projectPath] = project;
+  store.set('projectSettings', projectSettings);
+  return project;
+});
+
+const KEYTAR_SERVICE = 'Xtool Studio';
+
+ipcMain.handle('secret:get', async (_event, payload: { account: string }) => {
+  if (!payload.account) return null;
+  return keytar.getPassword(KEYTAR_SERVICE, payload.account);
+});
+
+ipcMain.handle('secret:set', async (_event, payload: { account: string; secret: string | null }) => {
+  const { account, secret } = payload;
+  if (!account) return false;
+  if (!secret) {
+    await keytar.deletePassword(KEYTAR_SERVICE, account);
+    return true;
+  }
+  await keytar.setPassword(KEYTAR_SERVICE, account, secret);
+  return true;
+});
+
+ipcMain.handle('xtool:run', async (_event, request: PtyRequest) => {
+  return ptyManager.spawn(request);
+});
+
+ipcMain.handle('xtool:kill', (_event, id: string) => {
+  ptyManager.kill(id);
+});
+
+ipcMain.handle('xtool:exec', async (_event, request: { command: string; args?: string[]; cwd?: string; env?: Record<string, string>; timeoutMs?: number }) => {
+  const { command, args = [], cwd = process.cwd(), env = {}, timeoutMs = 120000 } = request;
+  return new Promise<{ stdout: string; stderr: string; exitCode: number }>((resolve, reject) => {
+    const child = spawnChild(command, args, {
+      cwd,
+      env: { ...process.env, ...env },
+      shell: process.platform === 'win32'
+    });
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM');
+      reject(new Error('Command timed out'));
+    }, timeoutMs);
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', chunk => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on('data', chunk => {
+      stderr += chunk.toString();
+    });
+    child.on('error', err => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on('close', code => {
+      clearTimeout(timer);
+      resolve({ stdout, stderr, exitCode: code ?? 0 });
+    });
+  });
+});
+
+ipcMain.handle('sim:remote', async (_event, payload: {
+  host: string;
+  user: string;
+  sshKeyPath?: string;
+  bundleId: string;
+  appPath?: string;
+  deviceName: string;
+  action: 'boot' | 'install' | 'terminate' | 'launch' | 'screenshot';
+  screenshotPath?: string;
+}) => {
+  const { host, user, sshKeyPath, bundleId, appPath, deviceName, action, screenshotPath } = payload;
+  if (!host || !user) {
+    throw new Error('Missing SSH host or user');
+  }
+  const baseArgs = ['-o', 'StrictHostKeyChecking=no'];
+  if (sshKeyPath) {
+    baseArgs.push('-i', sshKeyPath);
+  }
+  const commandFragments: Record<typeof action, string> = {
+    boot: `xcrun simctl boot "${deviceName}" || true`,
+    install: `xcrun simctl install booted ${appPath ?? ''}`.trim(),
+    terminate: `xcrun simctl terminate booted ${bundleId} || true`,
+    launch: `xcrun simctl launch booted ${bundleId}`,
+    screenshot: `xcrun simctl io booted screenshot ${screenshotPath ?? '/tmp/xtool-sim.png'}`
+  };
+  const remoteCommand = commandFragments[action];
+  if (!remoteCommand) {
+    throw new Error('Unsupported action');
+  }
+  const sshArgs = [...baseArgs, `${user}@${host}`, remoteCommand];
+  const output = await runCommand('ssh', sshArgs);
+
+  if (action === 'screenshot' && screenshotPath) {
+    const scpArgs = [...baseArgs, `${user}@${host}:${screenshotPath}`, screenshotPath];
+    await runCommand('scp', scpArgs);
+  }
+
+  return output;
+});
+
+
+ipcMain.handle('problems:open', (_event, payload: { projectPath?: string; file: string; line: number; column: number }) => {
+  const { projectPath, file, line, column } = payload;
+  const absolute = path.isAbsolute(file) ? file : (projectPath ? path.join(projectPath, file) : file);
+  const vscodeUrl = `vscode://file/${absolute}:${line}:${column}`;
+  shell.openExternal(vscodeUrl);
+});
+
+ipcMain.handle('shell:openPath', (_event, targetPath: string) => {
+  if (targetPath) {
+    shell.openPath(targetPath);
+  }
+});
+
+function runCommand(command: string, args: string[]) {
+  return new Promise<{ stdout: string; stderr: string; exitCode: number }>((resolve, reject) => {
+    const child = spawnChild(command, args, {
+      env: process.env,
+      shell: process.platform === 'win32'
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', data => {
+      stdout += data.toString();
+    });
+    child.stderr?.on('data', data => {
+      stderr += data.toString();
+    });
+    child.on('error', reject);
+    child.on('close', code => {
+      resolve({ stdout, stderr, exitCode: code ?? 0 });
+    });
+  });
+}
+
+app.on('before-quit', () => {
+  ptyManager.dispose();
+});

--- a/src/main/pty.ts
+++ b/src/main/pty.ts
@@ -1,0 +1,74 @@
+import { BrowserWindow } from 'electron';
+import { randomUUID } from 'crypto';
+import { IPty, spawn } from 'node-pty';
+
+export interface PtyRequest {
+  command: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  cols?: number;
+  rows?: number;
+  id?: string;
+}
+
+export interface PtyResult {
+  id: string;
+  pid: number;
+}
+
+export class PtyManager {
+  private processes = new Map<string, IPty>();
+  private window: BrowserWindow | null = null;
+
+  bindWindow(window: BrowserWindow | null) {
+    this.window = window;
+  }
+
+  spawn(request: PtyRequest): PtyResult {
+    const id = request.id ?? randomUUID();
+    const { command, args = [], cwd = process.cwd(), env = {}, cols = 80, rows = 30 } = request;
+    const shellEnv = { ...process.env, ...env };
+    const defaultName = process.platform === 'win32' ? 'windows' : 'xterm-color';
+
+    const pty = spawn(command, args, {
+      name: defaultName,
+      cols,
+      rows,
+      cwd,
+      env: shellEnv,
+      useConpty: process.platform === 'win32'
+    });
+
+    this.processes.set(id, pty);
+
+    pty.onData(data => {
+      this.window?.webContents.send('pty:data', { id, data });
+    });
+
+    pty.onExit(event => {
+      this.window?.webContents.send('pty:exit', { id, code: event.exitCode, signal: event.signal });
+      this.processes.delete(id);
+    });
+
+    return { id, pid: pty.pid };
+  }
+
+  kill(id: string) {
+    const process = this.processes.get(id);
+    if (process) {
+      try {
+        process.kill();
+      } catch (error) {
+        console.error('Failed to kill process', error);
+      }
+      this.processes.delete(id);
+    }
+  }
+
+  dispose() {
+    for (const [id] of this.processes) {
+      this.kill(id);
+    }
+  }
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1,0 +1,103 @@
+import { contextBridge, ipcRenderer } from 'electron';
+
+type EnvMap = Record<string, string>;
+
+declare global {
+  interface Window {
+    xtool: {
+      run: (cwd: string, argv: string[], env?: EnvMap) => Promise<{ id: string; pid: number }>;
+      exec: (argv: string[], options: { cwd?: string; env?: EnvMap; timeoutMs?: number }) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+    };
+    proc: {
+      kill: (id: string) => Promise<void>;
+    };
+    settings: {
+      get: (scope: 'global' | 'project', key?: string, projectPath?: string) => Promise<any>;
+      set: (scope: 'global' | 'project', key: string, value: any, projectPath?: string) => Promise<any>;
+    };
+    secret: {
+      get: (account: string) => Promise<string | null>;
+      set: (account: string, secret: string | null) => Promise<boolean>;
+    };
+    sim: {
+      remote: (cfg: any) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+    };
+    bridge: {
+      onPtyData: (callback: (payload: { id: string; data: string }) => void) => () => void;
+      onPtyExit: (callback: (payload: { id: string; code: number; signal?: number }) => void) => () => void;
+      selectDirectory: () => Promise<string | null>;
+      getRecentProjects: () => Promise<string[]>;
+      addRecentProject: (projectPath: string) => Promise<string[]>;
+      analyzeProject: (projectPath: string) => Promise<{ hasPackageSwift: boolean; hasXtoolConfig: boolean } | null>;
+      openPath: (target: string) => Promise<void>;
+      openProblem: (payload: { projectPath?: string; file: string; line: number; column: number }) => Promise<void>;
+    };
+  }
+}
+
+const run = async (cwd: string, argv: string[], env?: EnvMap) => {
+  const xtoolPath = await ipcRenderer.invoke('settings:get', { scope: 'global', key: 'xtoolPath' });
+  const command = xtoolPath || (process.platform === 'win32' ? 'xtool.exe' : 'xtool');
+  return ipcRenderer.invoke('xtool:run', {
+    command,
+    args: argv,
+    cwd,
+    env
+  });
+};
+
+const exec = async (argv: string[], options: { cwd?: string; env?: EnvMap; timeoutMs?: number }) => {
+  const xtoolPath = await ipcRenderer.invoke('settings:get', { scope: 'global', key: 'xtoolPath' });
+  const command = xtoolPath || (process.platform === 'win32' ? 'xtool.exe' : 'xtool');
+  return ipcRenderer.invoke('xtool:exec', {
+    command,
+    args: argv,
+    cwd: options.cwd,
+    env: options.env,
+    timeoutMs: options.timeoutMs
+  });
+};
+
+contextBridge.exposeInMainWorld('xtool', {
+  run,
+  exec
+});
+
+contextBridge.exposeInMainWorld('proc', {
+  kill: (id: string) => ipcRenderer.invoke('xtool:kill', id)
+});
+
+contextBridge.exposeInMainWorld('settings', {
+  get: (scope: 'global' | 'project', key?: string, projectPath?: string) =>
+    ipcRenderer.invoke('settings:get', { scope, key, projectPath }),
+  set: (scope: 'global' | 'project', key: string, value: any, projectPath?: string) =>
+    ipcRenderer.invoke('settings:set', { scope, key, value, projectPath })
+});
+
+contextBridge.exposeInMainWorld('secret', {
+  get: (account: string) => ipcRenderer.invoke('secret:get', { account }),
+  set: (account: string, secret: string | null) => ipcRenderer.invoke('secret:set', { account, secret })
+});
+
+contextBridge.exposeInMainWorld('sim', {
+  remote: (cfg: any) => ipcRenderer.invoke('sim:remote', cfg)
+});
+
+contextBridge.exposeInMainWorld('bridge', {
+  onPtyData: (callback: (payload: { id: string; data: string }) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, payload: { id: string; data: string }) => callback(payload);
+    ipcRenderer.on('pty:data', listener);
+    return () => ipcRenderer.removeListener('pty:data', listener);
+  },
+  onPtyExit: (callback: (payload: { id: string; code: number; signal?: number }) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, payload: { id: string; code: number; signal?: number }) => callback(payload);
+    ipcRenderer.on('pty:exit', listener);
+    return () => ipcRenderer.removeListener('pty:exit', listener);
+  },
+  selectDirectory: () => ipcRenderer.invoke('dialog:selectDirectory'),
+  getRecentProjects: () => ipcRenderer.invoke('projects:getRecent'),
+  addRecentProject: (projectPath: string) => ipcRenderer.invoke('projects:addRecent', projectPath),
+  analyzeProject: (projectPath: string) => ipcRenderer.invoke('project:analyze', projectPath),
+  openPath: (target: string) => ipcRenderer.invoke('shell:openPath', target),
+  openProblem: (payload: { projectPath?: string; file: string; line: number; column: number }) => ipcRenderer.invoke('problems:open', payload)
+});

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,0 +1,546 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import ProjectPicker from './components/ProjectPicker';
+import DevicesPanel, { Device } from './components/Devices';
+import BuildPanel from './components/Build';
+import InstallLaunchPanel from './components/InstallLaunch';
+import LogsPanel, { LogEntry, LogFilter, Problem } from './components/Logs';
+import SettingsPanel, { GlobalSettings, ProjectSettings } from './components/Settings';
+import SimulatorBridgePanel, { SimulatorConfig } from './components/SimulatorBridge';
+
+const tabs = [
+  { id: 'project', label: 'Project' },
+  { id: 'devices', label: 'Devices' },
+  { id: 'build', label: 'Build' },
+  { id: 'install', label: 'Install & Launch' },
+  { id: 'logs', label: 'Logs' },
+  { id: 'settings', label: 'Settings' },
+  { id: 'simulator', label: 'Simulator' }
+] as const;
+
+const logLevels = {
+  info: 'info',
+  warning: 'warning',
+  error: 'error',
+  test: 'test'
+} as const;
+
+const defaultGlobalSettings: GlobalSettings = {
+  xtoolPath: typeof process !== 'undefined' && process.platform === 'win32' ? 'xtool.exe' : 'xtool',
+  defaultArgs: '',
+  defaultEnv: ''
+};
+
+const defaultProjectSettings: ProjectSettings = {
+  buildArgs: '',
+  installArgs: '',
+  launchArgs: '',
+  envVars: '',
+  bundleId: '',
+  teamId: '',
+  defaultDevice: '',
+  simulator: {
+    host: '',
+    user: '',
+    sshKeyPath: '',
+    deviceName: 'iPhone 15',
+    appPath: '',
+    screenshotPath: '/tmp/xtool-sim.png'
+  }
+};
+
+type Toast = {
+  id: string;
+  message: string;
+  level: 'error' | 'success';
+};
+
+type RunningProcess = {
+  id: string;
+  label: string;
+  startedAt: number;
+  args: string[];
+};
+
+type TabId = typeof tabs[number]['id'];
+
+type ProjectMeta = {
+  hasPackageSwift: boolean;
+  hasXtoolConfig: boolean;
+} | null;
+
+const parseEnv = (envText: string): Record<string, string> => {
+  const env: Record<string, string> = {};
+  envText
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(Boolean)
+    .forEach(line => {
+      const [key, ...rest] = line.split('=');
+      if (key) {
+        env[key.trim()] = rest.join('=').trim();
+      }
+    });
+  return env;
+};
+
+const mergeEnv = (globalEnv: string, projectEnv: string, overrides?: Record<string, string>) => ({
+  ...parseEnv(globalEnv),
+  ...parseEnv(projectEnv),
+  ...(overrides ?? {})
+});
+
+const App: React.FC = () => {
+  const [activeTab, setActiveTab] = useState<TabId>('project');
+  const [projectPath, setProjectPath] = useState<string | null>(null);
+  const [projectMeta, setProjectMeta] = useState<ProjectMeta>(null);
+  const [recentProjects, setRecentProjects] = useState<string[]>([]);
+  const [devices, setDevices] = useState<Device[]>([]);
+  const [devicesLoading, setDevicesLoading] = useState(false);
+  const [defaultDevice, setDefaultDevice] = useState<string>('');
+  const [globalSettings, setGlobalSettings] = useState<GlobalSettings>(defaultGlobalSettings);
+  const [projectSettings, setProjectSettings] = useState<ProjectSettings>(defaultProjectSettings);
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [logFilter, setLogFilter] = useState<LogFilter>('all');
+  const [logSearch, setLogSearch] = useState('');
+  const [problems, setProblems] = useState<Problem[]>([]);
+  const [status, setStatus] = useState<{ cwd: string; device: string; lastExitCode: number | null }>(
+    { cwd: '', device: '', lastExitCode: null }
+  );
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const [isLoopRunning, setIsLoopRunning] = useState(false);
+  const runningProcesses = useRef<Record<string, RunningProcess>>({});
+  const pendingResolvers = useRef<Record<string, (code: number) => void>>({});
+  const partialLogs = useRef<Record<string, string>>({});
+
+  const appendToast = useCallback((message: string, level: 'error' | 'success') => {
+    const id = window.crypto?.randomUUID ? window.crypto.randomUUID() : Math.random().toString(36).slice(2);
+    setToasts(prev => [...prev, { id, message, level }]);
+  }, []);
+
+  useEffect(() => {
+    const cleanupData = window.bridge.onPtyData(({ id, data }) => {
+      partialLogs.current[id] = (partialLogs.current[id] ?? '') + data;
+      const chunks = partialLogs.current[id].split(/\r?\n/);
+      partialLogs.current[id] = chunks.pop() ?? '';
+      const entries: LogEntry[] = [];
+      const newProblems: Problem[] = [];
+      chunks.forEach(chunk => {
+        if (!chunk.trim()) return;
+        const level = inferLogLevel(chunk);
+        const entry: LogEntry = {
+          id: window.crypto?.randomUUID ? window.crypto.randomUUID() : Math.random().toString(36).slice(2),
+          message: chunk,
+          level,
+          timestamp: Date.now(),
+          processId: id
+        };
+        entries.push(entry);
+        const problem = parseProblem(chunk);
+        if (problem) {
+          newProblems.push(problem);
+        }
+      });
+      if (entries.length) {
+        setLogs(prev => [...prev, ...entries]);
+      }
+      if (newProblems.length) {
+        setProblems(prev => [...prev, ...newProblems]);
+      }
+    });
+
+    const cleanupExit = window.bridge.onPtyExit(({ id, code }) => {
+      const resolver = pendingResolvers.current[id];
+      if (resolver) {
+        resolver(code);
+        delete pendingResolvers.current[id];
+      }
+      const proc = runningProcesses.current[id];
+      if (proc) {
+        setStatus(prev => ({ ...prev, lastExitCode: code }));
+        if (code !== 0) {
+          appendToast(`${proc.label} failed (exit code ${code})`, 'error');
+        }
+        delete runningProcesses.current[id];
+      }
+    });
+
+    return () => {
+      cleanupData();
+      cleanupExit();
+    };
+  }, [appendToast]);
+
+  useEffect(() => {
+    window.bridge.getRecentProjects().then(setRecentProjects);
+  }, []);
+
+  const inferLogLevel = useCallback((line: string): LogEntry['level'] => {
+    if (/error:/i.test(line)) return logLevels.error;
+    if (/warning:/i.test(line)) return logLevels.warning;
+    if (/test/i.test(line)) return logLevels.test;
+    return logLevels.info;
+  }, []);
+
+  const parseProblem = useCallback((line: string): Problem | null => {
+    const match = line.match(/([^\s:]+\.swift):(\d+):(\d+):(error|warning):\s*(.*)/i);
+    if (!match) return null;
+    return {
+      file: match[1],
+      line: Number(match[2]),
+      column: Number(match[3]),
+      level: match[4].toLowerCase() as Problem['level'],
+      message: match[5]
+    };
+  }, []);
+
+  const loadGlobalSettings = useCallback(async () => {
+    const stored = await window.settings.get('global');
+    setGlobalSettings(prev => ({ ...prev, ...(stored ?? {}) }));
+  }, []);
+
+  const loadProjectSettings = useCallback(async (selectedPath: string) => {
+    const stored = (await window.settings.get('project', undefined, selectedPath)) ?? {};
+    const merged = {
+      ...defaultProjectSettings,
+      ...stored,
+      simulator: { ...defaultProjectSettings.simulator, ...(stored.simulator ?? {}) }
+    };
+    setProjectSettings(merged);
+    setDefaultDevice(merged.defaultDevice ?? '');
+    setStatus(prev => ({ ...prev, cwd: selectedPath, device: merged.defaultDevice ?? '' }));
+  }, []);
+
+  useEffect(() => {
+    loadGlobalSettings();
+  }, [loadGlobalSettings]);
+
+  const handleProjectSelect = useCallback(
+    async (selected: string | null) => {
+      setProjectPath(selected);
+      if (selected) {
+        const meta = await window.bridge.analyzeProject(selected);
+        setProjectMeta(meta);
+        const updated = await window.bridge.addRecentProject(selected);
+        setRecentProjects(updated);
+        await loadProjectSettings(selected);
+      } else {
+        setProjectMeta(null);
+        setProjectSettings({ ...defaultProjectSettings, simulator: { ...defaultProjectSettings.simulator } });
+        setDefaultDevice('');
+        setStatus(prev => ({ ...prev, cwd: '', device: '', lastExitCode: null }));
+      }
+    },
+    [loadProjectSettings]
+  );
+
+  const runCommand = useCallback(
+    async (label: string, args: string[], envOverrides?: Record<string, string>) => {
+      if (!projectPath) {
+        appendToast('Select a project before running commands.', 'error');
+        throw new Error('No project selected');
+      }
+      const env = mergeEnv(globalSettings.defaultEnv ?? '', projectSettings.envVars ?? '', envOverrides);
+      const response = await window.xtool.run(projectPath, [...(globalSettings.defaultArgs?.split(' ').filter(Boolean) ?? []), ...args], env);
+      runningProcesses.current[response.id] = {
+        id: response.id,
+        label,
+        startedAt: Date.now(),
+        args
+      };
+      setStatus(prev => ({ ...prev, lastExitCode: null }));
+      const completion = new Promise<number>(resolve => {
+        pendingResolvers.current[response.id] = resolve;
+      });
+      return { id: response.id, completion };
+    },
+    [appendToast, globalSettings.defaultArgs, globalSettings.defaultEnv, projectPath, projectSettings.envVars]
+  );
+
+  const fetchDevices = useCallback(async () => {
+    if (!projectPath) return;
+    try {
+      setDevicesLoading(true);
+      const result = await window.xtool.exec(['devices'], { cwd: projectPath });
+      const parsed = parseDevices(result.stdout || result.stderr);
+      setDevices(parsed);
+      if (!defaultDevice && parsed.length) {
+        setDefaultDevice(parsed[0].udid);
+        await window.settings.set('project', 'defaultDevice', parsed[0].udid, projectPath);
+      }
+      setStatus(prev => ({ ...prev, device: projectSettings.defaultDevice ?? parsed[0]?.udid ?? '' }));
+    } catch (error: any) {
+      appendToast(`Failed to load devices: ${error.message ?? error}`, 'error');
+    } finally {
+      setDevicesLoading(false);
+    }
+  }, [appendToast, defaultDevice, projectPath, projectSettings.defaultDevice]);
+
+  const parseDevices = useCallback((output: string): Device[] => {
+    const lines = output.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
+    const list: Device[] = [];
+    lines.forEach(line => {
+      const match = line.match(/^(.*?) \(([^)]+)\) \[(.*?)\]$/);
+      if (match) {
+        list.push({ name: match[1], platform: match[2], udid: match[3] });
+      }
+    });
+    return list;
+  }, []);
+
+  useEffect(() => {
+    if (projectPath) {
+      fetchDevices();
+    }
+  }, [projectPath, fetchDevices]);
+
+  const handleSetDefaultDevice = useCallback(async (deviceId: string) => {
+    if (!projectPath) return;
+    setDefaultDevice(deviceId);
+    setProjectSettings(prev => ({ ...prev, defaultDevice: deviceId }));
+    setStatus(prev => ({ ...prev, device: deviceId }));
+    await window.settings.set('project', 'defaultDevice', deviceId, projectPath);
+  }, [projectPath]);
+
+  const handleBuild = useCallback(async () => {
+    const buildArgs = projectSettings.buildArgs?.split(' ').filter(Boolean) ?? [];
+    return runCommand('xtool dev', ['dev', ...buildArgs]);
+  }, [projectSettings.buildArgs, runCommand]);
+
+  const handleInstall = useCallback(async () => {
+    const installArgs = projectSettings.installArgs?.split(' ').filter(Boolean) ?? [];
+    const env: Record<string, string> = {};
+    if (defaultDevice) {
+      env.XTOOL_DEVICE = defaultDevice;
+    }
+    return runCommand('xtool install', ['install', ...installArgs], env);
+  }, [defaultDevice, projectSettings.installArgs, runCommand]);
+
+  const handleLaunch = useCallback(async () => {
+    const launchArgs = projectSettings.launchArgs?.split(' ').filter(Boolean) ?? [];
+    const env: Record<string, string> = {};
+    if (projectSettings.bundleId) {
+      env.XTOOL_BUNDLE_ID = projectSettings.bundleId;
+    }
+    if (projectPath) {
+      await window.xtool.exec(['launch', '--terminate'], { cwd: projectPath });
+    }
+    return runCommand('xtool launch', ['launch', ...launchArgs], env);
+  }, [projectPath, projectSettings.bundleId, projectSettings.launchArgs, runCommand]);
+
+  const runLoop = useCallback(async () => {
+    try {
+      setIsLoopRunning(true);
+      const build = await handleBuild();
+      const buildCode = await build.completion;
+      if (buildCode !== 0) return;
+      const install = await handleInstall();
+      const installCode = await install.completion;
+      if (installCode !== 0) return;
+      const launch = await handleLaunch();
+      await launch.completion;
+    } finally {
+      setIsLoopRunning(false);
+    }
+  }, [handleBuild, handleInstall, handleLaunch]);
+
+  const clearLogs = useCallback(() => {
+    partialLogs.current = {};
+    setLogs([]);
+    setProblems([]);
+  }, []);
+
+  const filteredLogs = useMemo(() => {
+    return logs.filter(entry => {
+      if (logFilter !== 'all' && entry.level !== logFilter) return false;
+      if (logSearch && !entry.message.toLowerCase().includes(logSearch.toLowerCase())) return false;
+      return true;
+    });
+  }, [logFilter, logSearch, logs]);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      const isMac = navigator.platform.toLowerCase().includes('mac');
+      const meta = isMac ? event.metaKey : event.ctrlKey;
+      if (!meta) return;
+      if (event.key.toLowerCase() === 'b') {
+        event.preventDefault();
+        handleBuild();
+      }
+      if (event.key.toLowerCase() === 'l') {
+        event.preventDefault();
+        handleLaunch();
+      }
+      if (event.key.toLowerCase() === 'k') {
+        event.preventDefault();
+        clearLogs();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [clearLogs, handleBuild, handleLaunch]);
+
+  const updateGlobalSetting = useCallback(async (key: keyof GlobalSettings, value: any) => {
+    setGlobalSettings(prev => ({ ...prev, [key]: value }));
+    await window.settings.set('global', key, value);
+  }, []);
+
+  const updateProjectSetting = useCallback(async (key: keyof ProjectSettings, value: any) => {
+    if (!projectPath) return;
+    setProjectSettings(prev => ({ ...prev, [key]: value }));
+    await window.settings.set('project', key, value, projectPath);
+  }, [projectPath]);
+
+  const updateSimulatorConfig = useCallback(async (config: SimulatorConfig) => {
+    await updateProjectSetting('simulator', config);
+  }, [updateProjectSetting]);
+
+  const handleToastDismiss = useCallback((toastId: string) => {
+    setToasts(prev => prev.filter(t => t.id !== toastId));
+  }, []);
+
+  const content = useMemo(() => {
+    switch (activeTab) {
+      case 'project':
+        return (
+          <ProjectPicker
+            projectPath={projectPath}
+            onProjectSelected={handleProjectSelect}
+            recentProjects={recentProjects}
+            projectMeta={projectMeta}
+          />
+        );
+      case 'devices':
+        return (
+          <DevicesPanel
+            devices={devices}
+            loading={devicesLoading}
+            defaultDevice={defaultDevice}
+            onRefresh={fetchDevices}
+            onSetDefault={handleSetDefaultDevice}
+          />
+        );
+      case 'build':
+        return (
+          <BuildPanel
+            buildArgs={projectSettings.buildArgs}
+            envVars={projectSettings.envVars}
+            onBuildArgsChange={value => updateProjectSetting('buildArgs', value)}
+            onEnvVarsChange={value => updateProjectSetting('envVars', value)}
+            onRunBuild={handleBuild}
+          />
+        );
+      case 'install':
+        return (
+          <InstallLaunchPanel
+            bundleId={projectSettings.bundleId}
+            teamId={projectSettings.teamId}
+            installArgs={projectSettings.installArgs}
+            launchArgs={projectSettings.launchArgs}
+            defaultDevice={defaultDevice}
+            onBundleChange={value => updateProjectSetting('bundleId', value)}
+            onTeamChange={value => updateProjectSetting('teamId', value)}
+            onInstallArgsChange={value => updateProjectSetting('installArgs', value)}
+            onLaunchArgsChange={value => updateProjectSetting('launchArgs', value)}
+            onInstall={handleInstall}
+            onLaunch={handleLaunch}
+            onTerminate={async () => {
+              if (!projectPath) return;
+              await window.xtool.exec(['launch', '--terminate'], { cwd: projectPath });
+            }}
+          />
+        );
+      case 'logs':
+        return (
+          <LogsPanel
+            logs={filteredLogs}
+            filter={logFilter}
+            onFilterChange={setLogFilter}
+            search={logSearch}
+            onSearchChange={setLogSearch}
+            onClear={clearLogs}
+            problems={problems}
+            onOpenProblem={problem => {
+              window.bridge.openProblem({ projectPath: projectPath ?? undefined, ...problem });
+            }}
+          />
+        );
+      case 'settings':
+        return (
+          <SettingsPanel
+            projectPath={projectPath}
+            globalSettings={globalSettings}
+            projectSettings={projectSettings}
+            onGlobalChange={updateGlobalSetting}
+            onProjectChange={updateProjectSetting}
+          />
+        );
+      case 'simulator':
+        return (
+          <SimulatorBridgePanel
+            config={projectSettings.simulator}
+            bundleId={projectSettings.bundleId}
+            onConfigChange={updateSimulatorConfig}
+          />
+        );
+      default:
+        return null;
+    }
+  }, [activeTab, clearLogs, devices, devicesLoading, defaultDevice, fetchDevices, filteredLogs, globalSettings, handleBuild, handleInstall, handleLaunch, handleProjectSelect, handleSetDefaultDevice, logFilter, logSearch, problems, projectPath, projectMeta, projectSettings, recentProjects, updateGlobalSetting, updateProjectSetting, updateSimulatorConfig]);
+
+  return (
+    <div className="app-shell">
+      <div className="top-bar">
+        <div>
+          <h1>Xtool Studio</h1>
+          <div className="project-path">{projectPath ?? 'No project selected'}</div>
+        </div>
+        <button disabled={!projectPath || isLoopRunning} onClick={runLoop}>
+          {isLoopRunning ? 'Running…' : 'One-Click Loop'}
+        </button>
+      </div>
+      <div className="main-content">
+        <div className="sidebar">
+          {tabs.map(tab => (
+            <button
+              key={tab.id}
+              className={tab.id === activeTab ? 'active' : ''}
+              onClick={() => setActiveTab(tab.id)}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+        <div className="content-area">{content}</div>
+      </div>
+      <div className="status-bar">
+        <span>Project: {status.cwd || '—'}</span>
+        <span>Device: {defaultDevice || '—'}</span>
+        <span>Last exit code: {status.lastExitCode ?? '—'}</span>
+      </div>
+      <div className="toast-container" style={{ position: 'fixed', bottom: 20, right: 20, display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        {toasts.map(toast => (
+          <div
+            key={toast.id}
+            style={{
+              background: toast.level === 'error' ? 'rgba(248,113,113,0.2)' : 'rgba(34,197,94,0.2)',
+              border: '1px solid rgba(148,163,184,0.3)',
+              borderRadius: 6,
+              padding: '0.75rem 1rem',
+              color: '#f8fafc',
+              minWidth: '240px'
+            }}
+          >
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '0.5rem' }}>
+              <span>{toast.message}</span>
+              <button className="secondary" style={{ padding: '0.2rem 0.4rem' }} onClick={() => handleToastDismiss(toast.id)}>
+                ×
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default App;

--- a/src/renderer/components/Build.tsx
+++ b/src/renderer/components/Build.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+
+type Props = {
+  buildArgs: string;
+  envVars: string;
+  onBuildArgsChange: (value: string) => void;
+  onEnvVarsChange: (value: string) => void;
+  onRunBuild: () => Promise<any>;
+};
+
+const BuildPanel: React.FC<Props> = ({ buildArgs, envVars, onBuildArgsChange, onEnvVarsChange, onRunBuild }) => {
+  const [isRunning, setIsRunning] = useState(false);
+
+  const handleRun = async () => {
+    setIsRunning(true);
+    try {
+      const result = await onRunBuild();
+      if (result?.completion) {
+        await result.completion;
+      }
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  return (
+    <div className="panel">
+      <h2>Build</h2>
+      <p>Configure build arguments and environment variables. Builds run via <code>xtool dev</code>.</p>
+      <div className="form-grid">
+        <label>
+          Extra build arguments
+          <input type="text" value={buildArgs} onChange={event => onBuildArgsChange(event.target.value)} placeholder="--verbose" />
+        </label>
+        <label>
+          Environment variables (KEY=VALUE per line)
+          <textarea value={envVars} onChange={event => onEnvVarsChange(event.target.value)} placeholder={'TEAM_ID=XXXXXX\nCUSTOM_FLAG=1'} />
+        </label>
+      </div>
+      <button className="primary" onClick={handleRun} disabled={isRunning}>
+        {isRunning ? 'Building…' : 'Build'}
+      </button>
+    </div>
+  );
+};
+
+export default BuildPanel;

--- a/src/renderer/components/Devices.tsx
+++ b/src/renderer/components/Devices.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+
+export type Device = {
+  name: string;
+  platform: string;
+  udid: string;
+};
+
+type Props = {
+  devices: Device[];
+  loading: boolean;
+  defaultDevice: string;
+  onRefresh: () => void;
+  onSetDefault: (udid: string) => void;
+};
+
+const DevicesPanel: React.FC<Props> = ({ devices, loading, defaultDevice, onRefresh, onSetDefault }) => {
+  return (
+    <div className="panel">
+      <h2>Connected Devices</h2>
+      <p>Devices are fetched from <code>xtool devices</code>. Select a default device for install operations.</p>
+      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.75rem' }}>
+        <span>{devices.length} devices detected</span>
+        <button className="secondary" onClick={onRefresh} disabled={loading}>
+          {loading ? 'Refreshing…' : 'Refresh'}
+        </button>
+      </div>
+      <table className="table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Platform</th>
+            <th>UDID</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {devices.map(device => (
+            <tr key={device.udid}>
+              <td>{device.name}</td>
+              <td>{device.platform}</td>
+              <td>{device.udid}</td>
+              <td>
+                <button
+                  className={device.udid === defaultDevice ? 'primary' : 'secondary'}
+                  onClick={() => onSetDefault(device.udid)}
+                >
+                  {device.udid === defaultDevice ? 'Default' : 'Set default'}
+                </button>
+              </td>
+            </tr>
+          ))}
+          {devices.length === 0 && (
+            <tr>
+              <td colSpan={4} style={{ textAlign: 'center', padding: '1rem' }}>
+                {loading ? 'Scanning devices…' : 'No devices found. Connect a device and refresh.'}
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default DevicesPanel;

--- a/src/renderer/components/InstallLaunch.tsx
+++ b/src/renderer/components/InstallLaunch.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+
+type Props = {
+  bundleId: string;
+  teamId: string;
+  installArgs: string;
+  launchArgs: string;
+  defaultDevice: string;
+  onBundleChange: (value: string) => void;
+  onTeamChange: (value: string) => void;
+  onInstallArgsChange: (value: string) => void;
+  onLaunchArgsChange: (value: string) => void;
+  onInstall: () => Promise<any>;
+  onLaunch: () => Promise<any>;
+  onTerminate: () => Promise<any>;
+};
+
+const InstallLaunchPanel: React.FC<Props> = ({
+  bundleId,
+  teamId,
+  installArgs,
+  launchArgs,
+  defaultDevice,
+  onBundleChange,
+  onTeamChange,
+  onInstallArgsChange,
+  onLaunchArgsChange,
+  onInstall,
+  onLaunch,
+  onTerminate
+}) => {
+  const [installing, setInstalling] = useState(false);
+  const [launching, setLaunching] = useState(false);
+  const [terminating, setTerminating] = useState(false);
+
+  const handleInstall = async () => {
+    setInstalling(true);
+    try {
+      const result = await onInstall();
+      if (result?.completion) {
+        await result.completion;
+      }
+    } finally {
+      setInstalling(false);
+    }
+  };
+
+  const handleLaunch = async () => {
+    setLaunching(true);
+    try {
+      const result = await onLaunch();
+      if (result?.completion) {
+        await result.completion;
+      }
+    } finally {
+      setLaunching(false);
+    }
+  };
+
+  const handleTerminate = async () => {
+    setTerminating(true);
+    try {
+      await onTerminate();
+    } finally {
+      setTerminating(false);
+    }
+  };
+
+  return (
+    <div className="panel">
+      <h2>Install & Launch</h2>
+      <p>Install and launch your app on the selected device. Configure identifiers and arguments below.</p>
+      <div className="form-grid">
+        <label>
+          Bundle Identifier
+          <input type="text" value={bundleId} onChange={event => onBundleChange(event.target.value)} placeholder="com.example.app" />
+        </label>
+        <label>
+          Team ID
+          <input type="text" value={teamId} onChange={event => onTeamChange(event.target.value)} placeholder="ABCDE12345" />
+        </label>
+        <label>
+          Install arguments
+          <input type="text" value={installArgs} onChange={event => onInstallArgsChange(event.target.value)} placeholder="--force" />
+        </label>
+        <label>
+          Launch arguments
+          <input type="text" value={launchArgs} onChange={event => onLaunchArgsChange(event.target.value)} placeholder="--clean" />
+        </label>
+      </div>
+      <div className="tag-cloud">
+        <span className="tag">Default device: {defaultDevice || 'Not set'}</span>
+      </div>
+      <div style={{ display: 'flex', gap: '0.75rem', marginTop: '1rem' }}>
+        <button className="primary" onClick={handleInstall} disabled={installing}>
+          {installing ? 'Installing…' : 'Install'}
+        </button>
+        <button className="primary" onClick={handleLaunch} disabled={launching}>
+          {launching ? 'Launching…' : 'Launch'}
+        </button>
+        <button className="secondary" onClick={handleTerminate} disabled={terminating}>
+          {terminating ? 'Terminating…' : 'Terminate app'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default InstallLaunchPanel;

--- a/src/renderer/components/Logs.tsx
+++ b/src/renderer/components/Logs.tsx
@@ -1,0 +1,88 @@
+import React, { useMemo, useState } from 'react';
+import AnsiUp from 'ansi_up';
+
+export type LogEntry = {
+  id: string;
+  message: string;
+  level: 'info' | 'warning' | 'error' | 'test';
+  timestamp: number;
+  processId: string;
+};
+
+export type LogFilter = 'all' | 'warning' | 'error' | 'test';
+
+export type Problem = {
+  file: string;
+  line: number;
+  column: number;
+  level: 'warning' | 'error';
+  message: string;
+};
+
+type Props = {
+  logs: LogEntry[];
+  filter: LogFilter;
+  search: string;
+  onFilterChange: (filter: LogFilter) => void;
+  onSearchChange: (value: string) => void;
+  onClear: () => void;
+  problems: Problem[];
+  onOpenProblem: (problem: Problem) => void;
+};
+
+const ansi = new AnsiUp();
+
+const LogsPanel: React.FC<Props> = ({ logs, filter, search, onFilterChange, onSearchChange, onClear, problems, onOpenProblem }) => {
+  const [showProblems, setShowProblems] = useState(true);
+
+  const renderedLogs = useMemo(() => {
+    return logs.map(entry => ({
+      ...entry,
+      html: ansi.ansi_to_html(entry.message)
+    }));
+  }, [logs]);
+
+  return (
+    <div className="panel">
+      <h2>Logs</h2>
+      <div className="logs-toolbar">
+        <select value={filter} onChange={event => onFilterChange(event.target.value as LogFilter)}>
+          <option value="all">All</option>
+          <option value="warning">Warnings</option>
+          <option value="error">Errors</option>
+          <option value="test">Tests</option>
+        </select>
+        <input type="search" placeholder="Search logs" value={search} onChange={event => onSearchChange(event.target.value)} />
+        <button className="secondary" onClick={onClear}>
+          Clear
+        </button>
+      </div>
+      <div className="logs-container">
+        {renderedLogs.map(entry => (
+          <div key={entry.id} className={`log-entry ${entry.level}`} dangerouslySetInnerHTML={{ __html: entry.html }} />
+        ))}
+        {renderedLogs.length === 0 && <div>No logs yet.</div>}
+      </div>
+      <div className="problems-list">
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <h3>Problems</h3>
+          <button className="secondary" onClick={() => setShowProblems(value => !value)}>
+            {showProblems ? 'Hide' : 'Show'}
+          </button>
+        </div>
+        {showProblems && (
+          <ul>
+            {problems.map((problem, index) => (
+              <li key={`${problem.file}-${problem.line}-${index}`} onClick={() => onOpenProblem(problem)}>
+                <strong>{problem.level.toUpperCase()}</strong> {problem.file}:{problem.line}:{problem.column} – {problem.message}
+              </li>
+            ))}
+            {problems.length === 0 && <li>No problems detected.</li>}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default LogsPanel;

--- a/src/renderer/components/ProjectPicker.tsx
+++ b/src/renderer/components/ProjectPicker.tsx
@@ -1,0 +1,55 @@
+import React, { useCallback } from 'react';
+
+type Props = {
+  projectPath: string | null;
+  onProjectSelected: (path: string | null) => void;
+  recentProjects: string[];
+  projectMeta: { hasPackageSwift: boolean; hasXtoolConfig: boolean } | null;
+};
+
+const ProjectPicker: React.FC<Props> = ({ projectPath, onProjectSelected, recentProjects, projectMeta }) => {
+  const handleBrowse = useCallback(async () => {
+    const selected = await window.bridge.selectDirectory();
+    if (selected) {
+      onProjectSelected(selected);
+    }
+  }, [onProjectSelected]);
+
+  return (
+    <div className="panel">
+      <h2>Project Picker</h2>
+      <p>Select your project directory. Recent projects are stored locally for quick access.</p>
+      <div className="form-grid">
+        <label>
+          Current project
+          <input type="text" value={projectPath ?? ''} readOnly placeholder="No project selected" />
+        </label>
+        <div style={{ display: 'flex', gap: '0.75rem' }}>
+          <button className="primary" onClick={handleBrowse}>Choose Directory</button>
+          <button className="secondary" onClick={() => onProjectSelected(null)}>Clear</button>
+        </div>
+      </div>
+      {projectMeta && (
+        <div className="tag-cloud">
+          <span className="tag">Package.swift: {projectMeta.hasPackageSwift ? 'Found' : 'Missing'}</span>
+          <span className="tag">xtool config: {projectMeta.hasXtoolConfig ? 'Found' : 'Missing'}</span>
+        </div>
+      )}
+      <div className="panel" style={{ marginTop: '1rem' }}>
+        <h3>Recent Projects</h3>
+        {recentProjects.length === 0 && <p>No recent projects yet.</p>}
+        {recentProjects.map(project => (
+          <div key={project} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.5rem' }}>
+            <span style={{ fontSize: '0.85rem' }}>{project}</span>
+            <div style={{ display: 'flex', gap: '0.5rem' }}>
+              <button className="secondary" onClick={() => onProjectSelected(project)}>Open</button>
+              <button className="secondary" onClick={() => window.bridge.openPath(project)}>Reveal</button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ProjectPicker;

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -1,0 +1,126 @@
+import React, { useEffect, useState } from 'react';
+
+export type GlobalSettings = {
+  xtoolPath: string;
+  defaultArgs?: string;
+  defaultEnv?: string;
+};
+
+export type ProjectSettings = {
+  buildArgs: string;
+  installArgs: string;
+  launchArgs: string;
+  envVars: string;
+  bundleId: string;
+  teamId: string;
+  defaultDevice?: string;
+  simulator: {
+    host: string;
+    user: string;
+    sshKeyPath?: string;
+    deviceName: string;
+    appPath?: string;
+    screenshotPath?: string;
+  };
+};
+
+type Props = {
+  projectPath: string | null;
+  globalSettings: GlobalSettings;
+  projectSettings: ProjectSettings;
+  onGlobalChange: (key: keyof GlobalSettings, value: any) => void;
+  onProjectChange: (key: keyof ProjectSettings, value: any) => void;
+};
+
+const SettingsPanel: React.FC<Props> = ({ projectPath, globalSettings, projectSettings, onGlobalChange, onProjectChange }) => {
+  const [appleToken, setAppleToken] = useState('');
+  const [tokenLoaded, setTokenLoaded] = useState(false);
+  const [tokenStatus, setTokenStatus] = useState<string | null>(null);
+
+  useEffect(() => {
+    window.secret.get('apple-api-token').then(token => {
+      setAppleToken(token ?? '');
+      setTokenLoaded(true);
+    });
+  }, []);
+
+  const handleTokenSave = async () => {
+    await window.secret.set('apple-api-token', appleToken.trim() ? appleToken.trim() : null);
+    setTokenStatus('Saved');
+    setTimeout(() => setTokenStatus(null), 2500);
+  };
+
+  return (
+    <div className="panel">
+      <h2>Settings</h2>
+      <p>Configure global and per-project defaults. Settings are persisted using electron-store and secrets via keytar.</p>
+      <div className="panel" style={{ marginTop: '1rem' }}>
+        <h3>Global</h3>
+        <div className="form-grid">
+          <label>
+            xtool path
+            <input type="text" value={globalSettings.xtoolPath ?? ''} onChange={event => onGlobalChange('xtoolPath', event.target.value)} />
+          </label>
+          <label>
+            Default arguments
+            <input type="text" value={globalSettings.defaultArgs ?? ''} onChange={event => onGlobalChange('defaultArgs', event.target.value)} />
+          </label>
+          <label>
+            Default environment (KEY=VALUE per line)
+            <textarea value={globalSettings.defaultEnv ?? ''} onChange={event => onGlobalChange('defaultEnv', event.target.value)} />
+          </label>
+        </div>
+        <div className="form-grid">
+          <label>
+            Apple API token
+            <input
+              type="password"
+              value={appleToken}
+              placeholder={tokenLoaded ? '••••••' : 'Loading…'}
+              onChange={event => setAppleToken(event.target.value)}
+            />
+          </label>
+          <button className="secondary" onClick={handleTokenSave} disabled={!tokenLoaded}>
+            Save token
+          </button>
+          {tokenStatus && <span className="tag">{tokenStatus}</span>}
+        </div>
+      </div>
+
+      <div className="panel" style={{ marginTop: '1rem' }}>
+        <h3>Per Project</h3>
+        {projectPath ? <p>Project: {projectPath}</p> : <p>Select a project to edit project-specific settings.</p>}
+        {projectPath && (
+          <div className="form-grid">
+            <label>
+              Bundle ID
+              <input type="text" value={projectSettings.bundleId} onChange={event => onProjectChange('bundleId', event.target.value)} />
+            </label>
+            <label>
+              Team ID
+              <input type="text" value={projectSettings.teamId} onChange={event => onProjectChange('teamId', event.target.value)} />
+            </label>
+            <label>
+              Default build args
+              <input type="text" value={projectSettings.buildArgs} onChange={event => onProjectChange('buildArgs', event.target.value)} />
+            </label>
+            <label>
+              Default install args
+              <input type="text" value={projectSettings.installArgs} onChange={event => onProjectChange('installArgs', event.target.value)} />
+            </label>
+            <label>
+              Default launch args
+              <input type="text" value={projectSettings.launchArgs} onChange={event => onProjectChange('launchArgs', event.target.value)} />
+            </label>
+            <label>
+              Environment overrides
+              <textarea value={projectSettings.envVars} onChange={event => onProjectChange('envVars', event.target.value)} />
+            </label>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SettingsPanel;

--- a/src/renderer/components/SimulatorBridge.tsx
+++ b/src/renderer/components/SimulatorBridge.tsx
@@ -1,0 +1,120 @@
+import React, { useMemo, useState } from 'react';
+
+export type SimulatorConfig = {
+  host: string;
+  user: string;
+  sshKeyPath?: string;
+  deviceName: string;
+  appPath?: string;
+  screenshotPath?: string;
+};
+
+type Props = {
+  config: SimulatorConfig;
+  bundleId: string;
+  onConfigChange: (config: SimulatorConfig) => void;
+};
+
+const SimulatorBridgePanel: React.FC<Props> = ({ config, bundleId, onConfigChange }) => {
+  const [busyAction, setBusyAction] = useState<string | null>(null);
+  const [output, setOutput] = useState<string>('');
+  const [screenshotPreview, setScreenshotPreview] = useState<string | null>(null);
+
+  const updateField = (key: keyof SimulatorConfig, value: string) => {
+    onConfigChange({ ...config, [key]: value });
+  };
+
+  const canRun = useMemo(() => config.host && config.user && bundleId, [bundleId, config.host, config.user]);
+
+  const runAction = async (action: 'boot' | 'install' | 'terminate' | 'launch' | 'screenshot') => {
+    if (!canRun) return;
+    setBusyAction(action);
+    try {
+      const response = await window.sim.remote({
+        host: config.host,
+        user: config.user,
+        sshKeyPath: config.sshKeyPath,
+        deviceName: config.deviceName,
+        appPath: config.appPath,
+        bundleId,
+        action,
+        screenshotPath: config.screenshotPath
+      });
+      const combined = [response.stdout, response.stderr].filter(Boolean).join('\n');
+      setOutput(combined || `Command ${action} completed with exit code ${response.exitCode}`);
+      if (action === 'screenshot' && config.screenshotPath) {
+        setScreenshotPreview(`file://${config.screenshotPath}`);
+      }
+    } catch (error: any) {
+      setOutput(`Failed to run ${action}: ${error.message ?? error}`);
+    } finally {
+      setBusyAction(null);
+    }
+  };
+
+  return (
+    <div className="panel">
+      <h2>Remote Simulator Bridge</h2>
+      <p>Optionally control a remote macOS simulator host over SSH.</p>
+      <div className="form-grid">
+        <label>
+          Hostname / IP
+          <input type="text" value={config.host} onChange={event => updateField('host', event.target.value)} placeholder="simulator.local" />
+        </label>
+        <label>
+          SSH user
+          <input type="text" value={config.user} onChange={event => updateField('user', event.target.value)} placeholder="devuser" />
+        </label>
+        <label>
+          SSH key path
+          <input type="text" value={config.sshKeyPath ?? ''} onChange={event => updateField('sshKeyPath', event.target.value)} placeholder="~/.ssh/id_ed25519" />
+        </label>
+        <label>
+          Simulator device name
+          <input type="text" value={config.deviceName} onChange={event => updateField('deviceName', event.target.value)} placeholder="iPhone 15" />
+        </label>
+        <label>
+          App bundle path (.app)
+          <input type="text" value={config.appPath ?? ''} onChange={event => updateField('appPath', event.target.value)} placeholder="/path/to/MyApp.app" />
+        </label>
+        <label>
+          Screenshot path
+          <input type="text" value={config.screenshotPath ?? ''} onChange={event => updateField('screenshotPath', event.target.value)} placeholder="/tmp/xtool-sim.png" />
+        </label>
+      </div>
+      <div className="tag-cloud">
+        <span className="tag">Bundle ID: {bundleId || 'Set in Install tab'}</span>
+      </div>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', marginTop: '1rem' }}>
+        <button className="secondary" disabled={!canRun || busyAction === 'boot'} onClick={() => runAction('boot')}>
+          {busyAction === 'boot' ? 'Booting…' : 'Boot Simulator'}
+        </button>
+        <button className="secondary" disabled={!canRun || busyAction === 'install'} onClick={() => runAction('install')}>
+          {busyAction === 'install' ? 'Installing…' : 'Install .app'}
+        </button>
+        <button className="secondary" disabled={!canRun || busyAction === 'terminate'} onClick={() => runAction('terminate')}>
+          {busyAction === 'terminate' ? 'Terminating…' : 'Terminate'}
+        </button>
+        <button className="secondary" disabled={!canRun || busyAction === 'launch'} onClick={() => runAction('launch')}>
+          {busyAction === 'launch' ? 'Launching…' : 'Launch'}
+        </button>
+        <button className="secondary" disabled={!canRun || busyAction === 'screenshot'} onClick={() => runAction('screenshot')}>
+          {busyAction === 'screenshot' ? 'Capturing…' : 'Screenshot'}
+        </button>
+      </div>
+      {output && (
+        <pre className="logs-container" style={{ marginTop: '1rem' }}>
+          {output}
+        </pre>
+      )}
+      {screenshotPreview && (
+        <div className="remote-preview">
+          <h3>Screenshot</h3>
+          <img src={screenshotPreview} alt="Simulator screenshot" />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SimulatorBridgePanel;

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -1,0 +1,34 @@
+export {};
+
+declare global {
+  interface Window {
+    xtool: {
+      run: (cwd: string, argv: string[], env?: Record<string, string>) => Promise<{ id: string; pid: number }>;
+      exec: (argv: string[], options: { cwd?: string; env?: Record<string, string>; timeoutMs?: number }) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+    };
+    proc: {
+      kill: (id: string) => Promise<void>;
+    };
+    settings: {
+      get: (scope: 'global' | 'project', key?: string, projectPath?: string) => Promise<any>;
+      set: (scope: 'global' | 'project', key: string, value: any, projectPath?: string) => Promise<any>;
+    };
+    secret: {
+      get: (account: string) => Promise<string | null>;
+      set: (account: string, secret: string | null) => Promise<boolean>;
+    };
+    sim: {
+      remote: (cfg: any) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+    };
+    bridge: {
+      onPtyData: (callback: (payload: { id: string; data: string }) => void) => () => void;
+      onPtyExit: (callback: (payload: { id: string; code: number; signal?: number }) => void) => () => void;
+      selectDirectory: () => Promise<string | null>;
+      getRecentProjects: () => Promise<string[]>;
+      addRecentProject: (projectPath: string) => Promise<string[]>;
+      analyzeProject: (projectPath: string) => Promise<{ hasPackageSwift: boolean; hasXtoolConfig: boolean } | null>;
+      openPath: (target: string) => Promise<void>;
+      openProblem: (payload: { projectPath?: string; file: string; line: number; column: number }) => Promise<void>;
+    };
+  }
+}

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' http://localhost:5173 ws://localhost:5173;" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Xtool Studio</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./index.tsx"></script>
+  </body>
+</html>

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './styles.css';
+
+const container = document.getElementById('root');
+if (!container) {
+  throw new Error('Root container not found');
+}
+
+const root = createRoot(container);
+root.render(<App />);

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1,0 +1,296 @@
+:root {
+  color-scheme: dark;
+  font-family: 'Inter', 'Segoe UI', sans-serif;
+  background-color: #0f172a;
+  color: #f8fafc;
+}
+
+body {
+  margin: 0;
+  background-color: #0f172a;
+  color: #f8fafc;
+  height: 100vh;
+}
+
+#root {
+  height: 100vh;
+}
+
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.top-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  background: #111827;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.top-bar h1 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.top-bar .project-path {
+  font-size: 0.85rem;
+  color: #cbd5f5;
+}
+
+.top-bar button {
+  background: #2563eb;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.top-bar button:disabled {
+  background: rgba(37, 99, 235, 0.4);
+  cursor: not-allowed;
+}
+
+.main-content {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+.sidebar {
+  width: 240px;
+  background: #0b1120;
+  border-right: 1px solid rgba(148, 163, 184, 0.2);
+  display: flex;
+  flex-direction: column;
+}
+
+.sidebar button {
+  background: none;
+  color: #cbd5f5;
+  border: none;
+  padding: 0.75rem 1rem;
+  text-align: left;
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+
+.sidebar button.active,
+.sidebar button:hover {
+  background: rgba(37, 99, 235, 0.2);
+  color: #fff;
+}
+
+.content-area {
+  flex: 1;
+  padding: 1rem;
+  overflow-y: auto;
+}
+
+.status-bar {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  font-size: 0.8rem;
+  background: #0b1120;
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.panel {
+  background: rgba(15, 23, 42, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.panel h2 {
+  margin-top: 0;
+  font-size: 1.1rem;
+}
+
+.form-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.form-grid label {
+  font-size: 0.85rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+input[type='text'],
+input[type='password'],
+textarea,
+select {
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 6px;
+  padding: 0.45rem 0.6rem;
+  color: #e2e8f0;
+  font-size: 0.9rem;
+  font-family: inherit;
+}
+
+textarea {
+  min-height: 80px;
+  resize: vertical;
+}
+
+button.primary {
+  background: #2563eb;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+button.secondary {
+  background: rgba(37, 99, 235, 0.15);
+  color: #bfdbfe;
+  border: 1px solid rgba(37, 99, 235, 0.4);
+  border-radius: 6px;
+  padding: 0.45rem 1rem;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+button.danger {
+  background: rgba(248, 113, 113, 0.2);
+  color: #fecaca;
+  border: 1px solid rgba(248, 113, 113, 0.5);
+}
+
+.logs-container {
+  background: #030712;
+  border-radius: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 0.5rem;
+  max-height: 360px;
+  overflow-y: auto;
+  font-family: 'Source Code Pro', 'Fira Code', monospace;
+  font-size: 0.85rem;
+  white-space: pre-wrap;
+}
+
+.logs-toolbar {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  align-items: center;
+}
+
+.logs-toolbar input {
+  flex: 1;
+}
+
+.problems-list {
+  margin-top: 0.75rem;
+  background: rgba(30, 41, 59, 0.8);
+  border-radius: 6px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 0.5rem;
+}
+
+.problems-list h3 {
+  margin-top: 0;
+  font-size: 0.9rem;
+}
+
+.problems-list ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.problems-list li {
+  padding: 0.35rem 0;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+  cursor: pointer;
+}
+
+.problems-list li:last-child {
+  border-bottom: none;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  padding: 0.6rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+  text-align: left;
+}
+
+.badge {
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+}
+
+.badge.success {
+  background: rgba(34, 197, 94, 0.15);
+  color: #bbf7d0;
+}
+
+.badge.warning {
+  background: rgba(234, 179, 8, 0.15);
+  color: #fef08a;
+}
+
+.badge.error {
+  background: rgba(248, 113, 113, 0.2);
+  color: #fecaca;
+}
+
+.tag-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.tag {
+  background: rgba(148, 163, 184, 0.15);
+  color: #cbd5f5;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+}
+
+.remote-preview {
+  margin-top: 1rem;
+  text-align: center;
+}
+
+.remote-preview img {
+  max-width: 100%;
+  border-radius: 6px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.log-entry {
+  padding: 0.2rem 0;
+}
+.log-entry.warning {
+  color: #facc15;
+}
+.log-entry.error {
+  color: #f87171;
+}
+.log-entry.test {
+  color: #38bdf8;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "baseUrl": "."
+  },
+  "include": []
+}

--- a/tsconfig.main.json
+++ b/tsconfig.main.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/main",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "types": ["node"],
+    "target": "ES2020"
+  },
+  "include": ["src/main/**/*.ts"]
+}

--- a/tsconfig.preload.json
+++ b/tsconfig.preload.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/preload",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "types": ["node"],
+    "target": "ES2020"
+  },
+  "include": ["src/preload/**/*.ts"]
+}

--- a/tsconfig.renderer.json
+++ b/tsconfig.renderer.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "allowSyntheticDefaultImports": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "types": ["vite/client"],
+    "noEmit": true
+  },
+  "include": ["src/renderer/**/*"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  root: 'src/renderer',
+  base: './',
+  plugins: [react()],
+  build: {
+    outDir: '../../dist/renderer',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: path.resolve(__dirname, 'src/renderer/index.html')
+    }
+  },
+  server: {
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- add project configuration, build scripts, and bundler setup for the Xtool Studio Electron app
- implement the Electron main and preload processes to wrap xtool commands, persist settings, and manage remote simulator actions
- build a React renderer UI with panels for project management, device selection, build/install/launch workflows, live logs, settings, and optional simulator bridge

## Testing
- npm install *(fails: registry access forbidden in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68fad5c9fb4083309ace3e1a3a7bacab