### PR TITLE
Fix API generation rename step for Linux compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,9 +152,7 @@ api: openapi/openapi.json
 		openapi/openapi.json \
 		--config Sources/DeveloperAPI/openapi-generator-config.yaml \
 		--output-directory Sources/DeveloperAPI/Generated
-	for file in Sources/DeveloperAPI/Generated/*.swift; do \
-		sed -i '' -e 's/[[:<:]]Client[[:>:]]/DeveloperAPIClient/g' $$file; \
-	done
+        python3 scripts/rename-generated-client.py Sources/DeveloperAPI/Generated/*.swift
 
 .PHONY: update-api
 # Update OpenAPI spec and regenerate the client code

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ api: openapi/openapi.json
 		openapi/openapi.json \
 		--config Sources/DeveloperAPI/openapi-generator-config.yaml \
 		--output-directory Sources/DeveloperAPI/Generated
-        python3 scripts/rename-generated-client.py Sources/DeveloperAPI/Generated/*.swift
+	python3 scripts/rename-generated-client.py Sources/DeveloperAPI/Generated/*.swift
 
 .PHONY: update-api
 # Update OpenAPI spec and regenerate the client code

--- a/scripts/rename-generated-client.py
+++ b/scripts/rename-generated-client.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Rename generated Swift `Client` symbols to `DeveloperAPIClient`.
+
+This replaces standalone occurrences of the identifier `Client` with
+`DeveloperAPIClient` to avoid name clashes with other client types.  The
+previous implementation relied on `sed -i ''`, which only works on macOS.
+Using Python keeps the regeneration pipeline working on Linux systems such as
+Ubuntu.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+PATTERN = re.compile(r"\bClient\b")
+
+
+def rewrite_file(path: Path) -> None:
+    original = path.read_text(encoding="utf-8")
+    updated = PATTERN.sub("DeveloperAPIClient", original)
+    if updated != original:
+        path.write_text(updated, encoding="utf-8")
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("usage: rename-generated-client.py <swift-file> [<swift-file> ...]", file=sys.stderr)
+        return 1
+
+    for name in argv[1:]:
+        rewrite_file(Path(name))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary
- replace the macOS-specific sed invocation in the API generation Makefile rule with a Python helper script
- add the new helper script to safely rewrite generated Client symbols on any platform

## Testing
- python3 scripts/rename-generated-client.py Sources/DeveloperAPI/Generated/Client.swift

------
https://chatgpt.com/codex/tasks/task_e_68fb56ca7ae08330aceddba3496e9f8c